### PR TITLE
Fix: get user profile without primary membership

### DIFF
--- a/src/hooks/useDestinyMembership.ts
+++ b/src/hooks/useDestinyMembership.ts
@@ -10,10 +10,10 @@ export const useDestinyMembership = () => {
     queryKey: ["membershipData", session.data.bungieMembershipId],
     queryFn: () => bungie.getMembershipData(session.data),
     select: (data) =>
-      data.destinyMemberships.find(
-        (membership) =>
-          membership.membershipId === data.primaryMembershipId ||
-          !!membership.applicableMembershipTypes.length
-      ) ?? data.destinyMemberships[0],
+      data.profiles.sort(
+        (a, b) =>
+          new Date(b.dateLastPlayed).getTime() -
+          new Date(a.dateLastPlayed).getTime()
+      )[0],
   });
 };

--- a/src/lib/BungieClient.ts
+++ b/src/lib/BungieClient.ts
@@ -3,10 +3,10 @@ import {
   AllDestinyManifestComponents,
   getDestinyManifestComponent,
 } from "bungie-net-core/manifest";
-import { getMembershipDataForCurrentUser } from "bungie-net-core/endpoints/User";
 import {
   getActivityHistory,
   getDestinyManifest,
+  getLinkedProfiles,
   getProfile,
 } from "bungie-net-core/endpoints/Destiny2";
 import {
@@ -97,10 +97,15 @@ export class BungieHttpClient {
     });
   }
 
-  async getMembershipData(params: { accessToken: string }) {
-    return await getMembershipDataForCurrentUser(
-      this.platformHttp(params.accessToken)
-    ).then((res) => res.Response);
+  async getMembershipData(params: {
+    accessToken: string;
+    bungieMembershipId: string;
+  }) {
+    return await getLinkedProfiles(this.platformHttp(params.accessToken), {
+      membershipId: params.bungieMembershipId,
+      membershipType: -1,
+      getAllMemberships: true,
+    }).then((res) => res.Response);
   }
 
   async getBasicProfile(params: {


### PR DESCRIPTION
Replaced `GetMembershipsForCurrentUser` with `GetLinkedProfiles` method to ensure that the user profile is retrieved correctly. If the user has multiple destiny memberships without being connected with Cross save, `GetMembershipsForCurrentUser` will not include the `primaryMembershipId` key.